### PR TITLE
Upgrade release workflow versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, windows-latest, windows-2025, windows-2022, windows-2019, macos-13, macos-latest, macos-14, macos-15]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -35,7 +35,7 @@ jobs:
           make executable EXE_NAME=vpi-${{ matrix.os }}
 
       - name: Upload executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vpi-${{ matrix.os }}
           path: bin
@@ -46,7 +46,7 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts/
 


### PR DESCRIPTION
Fix release workflow by upgrading versions for `checkout`, `upload-artifact`, and `download-artifact`. 